### PR TITLE
Working update

### DIFF
--- a/population.c
+++ b/population.c
@@ -19,11 +19,14 @@ int main(void)
   while (end <= start);
   
     // TODO: Calculate number of years until we reach threshold
-  int years, born, died, growth;
-    for (years = 0; (start < end); years++) {
+  int years, born, died;
+  years = 0;
+  
+    while (start < end) {
         born = start / 3;
         died = start / 4;
         start = start + born - died;
+        years++;
     }
     // TODO: Print number of years
     printf("Years: %i\n", years);


### PR DESCRIPTION
re-arrange loop out of a for loop to be a while loop instead, as for loop e.g. for (years = 0; (start < end); years++) throws error = variables 'start' and 'end' used in loop condition not modified in loop body